### PR TITLE
feat: blog UI improvements and pnpm deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,13 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
 
-      - run: npm ci
-      - run: npm run build
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
 
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -117,7 +117,7 @@ export default async function Blog({ params }: PageProps) {
           if (headings.length === 0) return null;
           return (
             <aside className='hidden xl:block absolute -left-48 top-0 w-40 h-full'>
-              <nav className='sticky top-24 text-xs'>
+              <nav className='sticky top-24 text-xs max-h-[calc(100vh-8rem)] overflow-y-auto'>
                 <p className='text-neutral-400 dark:text-neutral-500 mb-2 font-medium'>目录</p>
                 <ul className='space-y-1.5'>
                   {headings.map((h) => (

--- a/app/blog/page/[page]/page.tsx
+++ b/app/blog/page/[page]/page.tsx
@@ -1,13 +1,31 @@
 import Link from 'next/link'
 import { BlogPosts } from '@/components/posts'
 import { AnimateIn } from '@/components/animate-in'
+import { getBlogPosts } from '@/app/blog/utils'
+
+const PAGE_SIZE = 10
+
+export function generateStaticParams() {
+  const total = getBlogPosts().length
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  return Array.from({ length: totalPages }, (_, i) => ({
+    page: String(i + 1),
+  }))
+}
 
 export const metadata = {
   title: 'Blog',
   description: '探索、记录、分享',
 }
 
-export default function Page() {
+type PageProps = {
+  params: Promise<{ page: string }>
+}
+
+export default async function Page({ params }: PageProps) {
+  const { page } = await params
+  const pageNum = parseInt(page, 10)
+
   return (
     <section>
       <AnimateIn>
@@ -28,7 +46,7 @@ export default function Page() {
         </div>
       </AnimateIn>
       <AnimateIn delay={1}>
-        <BlogPosts page={1} />
+        <BlogPosts page={pageNum} pageSize={PAGE_SIZE} />
       </AnimateIn>
     </section>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { BlogPosts } from '@/components/posts'
 import { AnimateIn } from '@/components/animate-in'
 
@@ -24,22 +23,6 @@ export default function Page() {
         <blockquote className="my-6 border-l-2 border-neutral-300 dark:border-neutral-600 pl-4 text-neutral-600 dark:text-neutral-400 italic">
           "世上只有一种英雄主义，就是在认清生活真相之后依然热爱生活。" ——罗曼·罗兰
         </blockquote>
-        <div className="flex gap-4 text-sm mb-8">
-          <a
-            href="https://bento.me/popring"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
-          >
-            bento.me ↗
-          </a>
-          <Link
-            href="/blog/2025-nian-du-shu-bi-ji-hui-zong"
-            className="text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
-          >
-            读书笔记 →
-          </Link>
-        </div>
       </AnimateIn>
       <AnimateIn delay={3} className="my-8">
         <BlogPosts limit={5} />

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -10,9 +10,6 @@ const navItems = {
   '/blog': {
     name: 'blog',
   },
-  '/blog/tags': {
-    name: 'tags',
-  },
 }
 
 export function Navbar() {

--- a/components/posts.tsx
+++ b/components/posts.tsx
@@ -7,7 +7,7 @@ type BlogPostsProps = {
   pageSize?: number
 }
 
-export function BlogPosts({ limit, page, pageSize = 5 }: BlogPostsProps) {
+export function BlogPosts({ limit, page, pageSize = 10 }: BlogPostsProps) {
   const allBlogs = getBlogPosts().sort((a, b) => {
     if (new Date(a.metadata.publishedAt) > new Date(b.metadata.publishedAt)) {
       return -1
@@ -49,7 +49,7 @@ export function BlogPosts({ limit, page, pageSize = 5 }: BlogPostsProps) {
         <nav className="flex items-center justify-between mt-8 text-sm text-neutral-600 dark:text-neutral-400">
           {page > 1 ? (
             <Link
-              href={page === 2 ? '/blog' : `/blog?page=${page - 1}`}
+              href={page === 2 ? '/blog' : `/blog/page/${page - 1}`}
               className="hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
             >
               上一页
@@ -60,7 +60,7 @@ export function BlogPosts({ limit, page, pageSize = 5 }: BlogPostsProps) {
           <span>{page} / {totalPages}</span>
           {page < totalPages ? (
             <Link
-              href={`/blog?page=${page + 1}`}
+              href={`/blog/page/${page + 1}`}
               className="hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors"
             >
               下一页


### PR DESCRIPTION
## Summary
- Add route-based pagination (/blog/page/[page]) for static export compatibility, 10 posts per page
- Add tags/categories pill links on blog listing page
- Remove bento.me and reading notes links from homepage
- Remove tags nav item from header
- Fix TOC overflow with max-height and scroll
- Switch GitHub Pages deploy from npm to pnpm

## Test plan
- [ ] Verify blog pagination works across pages
- [ ] Verify tags/categories links on blog page
- [ ] Verify homepage no longer shows bento/reading notes
- [ ] Verify long TOC scrolls on blog detail pages
- [ ] Verify GitHub Pages deploy succeeds with pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)