### PR TITLE
fix: lockfile for CI and TOC replaceState

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { formatDate, getBlogPosts } from '@/app/blog/utils';
 import { baseUrl } from '@/app/sitemap';
 import { AnimateIn } from '@/components/animate-in';
 import { GiscusComments } from '@/components/giscus';
+import { TableOfContents } from '@/components/toc';
 
 function getHeadings(content: string) {
   const headingRegex = /^(#{2,3})\s+(.+)$/gm;
@@ -115,25 +116,7 @@ export default async function Blog({ params }: PageProps) {
         {(() => {
           const headings = getHeadings(post.content);
           if (headings.length === 0) return null;
-          return (
-            <aside className='hidden xl:block absolute -left-48 top-0 w-40 h-full'>
-              <nav className='sticky top-24 text-xs max-h-[calc(100vh-8rem)] overflow-y-auto'>
-                <p className='text-neutral-400 dark:text-neutral-500 mb-2 font-medium'>目录</p>
-                <ul className='space-y-1.5'>
-                  {headings.map((h) => (
-                    <li key={h.slug} className={h.level === 3 ? 'ml-3' : ''}>
-                      <a
-                        href={`#${h.slug}`}
-                        className='text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 transition-colors leading-snug block'
-                      >
-                        {h.text}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
-            </aside>
-          );
+          return <TableOfContents headings={headings} />;
         })()}
         <AnimateIn delay={2}>
           <article className='prose'>

--- a/components/toc.tsx
+++ b/components/toc.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+type Heading = {
+  level: number
+  text: string
+  slug: string
+}
+
+export function TableOfContents({ headings }: { headings: Heading[] }) {
+  function handleClick(e: React.MouseEvent<HTMLAnchorElement>, slug: string) {
+    e.preventDefault()
+    const el = document.getElementById(slug)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' })
+      history.replaceState(null, '', `#${slug}`)
+    }
+  }
+
+  return (
+    <aside className='hidden xl:block absolute -left-48 top-0 w-40 h-full'>
+      <nav className='sticky top-24 text-xs max-h-[calc(100vh-8rem)] overflow-y-auto'>
+        <p className='text-neutral-400 dark:text-neutral-500 mb-2 font-medium'>目录</p>
+        <ul className='space-y-1.5'>
+          {headings.map((h) => (
+            <li key={h.slug} className={h.level === 3 ? 'ml-3' : ''}>
+              <a
+                href={`#${h.slug}`}
+                onClick={(e) => handleClick(e, h.slug)}
+                className='text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 transition-colors leading-snug block'
+              >
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: 16.1.1
         version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       geist:
-        specifier: 1.2.2
-        version: 1.2.2(next@16.1.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        specifier: ^1.7.0
+        version: 1.7.0(next@16.1.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1281,10 +1281,10 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  geist@1.2.2:
-    resolution: {integrity: sha512-uRDrxhvdnPwWJmh+K5+/5LXSKwvJzaYCl9tDXgiBi4hj7hB4K7+n/WLcvJMFs5btvyn0r9OSwCd1s6CmqAsxEw==}
+  geist@1.7.0:
+    resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
     peerDependencies:
-      next: '>=13.2.0 <15'
+      next: '>=13.2.0'
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3706,7 +3706,7 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.2.2(next@16.1.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  geist@1.7.0(next@16.1.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       next: 16.1.1(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 


### PR DESCRIPTION
## Summary
- Regenerate pnpm-lock.yaml to fix geist version mismatch causing CI failure
- Extract TOC into client component, use `history.replaceState` instead of push to prevent hash navigation from polluting browser history (so back button works correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)