### PR TITLE
fix: restore code syntax highlighting and add language label

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -109,15 +109,15 @@ html {
 .prose pre code {
   @apply p-0 bg-transparent text-inherit;
   border: initial;
-  --sh-class: initial;
-  --sh-identifier: initial;
-  --sh-sign: initial;
-  --sh-string: initial;
-  --sh-keyword: initial;
-  --sh-comment: initial;
-  --sh-jsxliterals: initial;
-  --sh-property: initial;
-  --sh-entity: initial;
+  --sh-class: inherit;
+  --sh-identifier: inherit;
+  --sh-sign: inherit;
+  --sh-string: inherit;
+  --sh-keyword: inherit;
+  --sh-comment: inherit;
+  --sh-jsxliterals: inherit;
+  --sh-property: inherit;
+  --sh-entity: inherit;
 }
 
 .prose code span {

--- a/blog/skeleton-screen-optimization.mdx
+++ b/blog/skeleton-screen-optimization.mdx
@@ -142,9 +142,9 @@ content && (document.querySelector('#skeleton-script').parentElement.innerHTML +
 
 可以将骨架屏渲染在一个空的 `div` 中，并通过 `fixed` 样式将其固定在页面的最上层。随后，监听页面实际渲染的状态，页面渲染完成后将骨架图隐藏，从而在视觉上达到良好的效果。
 
-**新增改动1：**script defer修改，经调试 `vite` [源码](https://github.com/vitejs/vite/blob/e59e2cacab476305c3cdfb31732c27b174fb8fe2/packages/vite/src/node/plugins/html.ts#L723) 发现已内置 `async`，另外，由于 type="module" 情况默认就是 `defer` , 所以其实不需要加都可以。（尴尬）
+**新增改动1：** script defer修改，经调试 `vite` [源码](https://github.com/vitejs/vite/blob/e59e2cacab476305c3cdfb31732c27b174fb8fe2/packages/vite/src/node/plugins/html.ts#L723) 发现已内置 `async`，另外，由于 type="module" 情况默认就是 `defer` , 所以其实不需要加都可以。（尴尬）
 
-**新增改动2：**plugin注入代码调整：
+**新增改动2：** plugin注入代码调整：
 
 ```js
 import { PluginOption } from 'vite';

--- a/components/mdx.tsx
+++ b/components/mdx.tsx
@@ -63,10 +63,17 @@ function TableWrapper(props: React.ComponentProps<'table'>) {
   )
 }
 
-function Pre({ children, ...props }: { children: React.ReactElement<{ children: string }> }) {
+function Pre({ children, ...props }: { children: React.ReactElement<{ children: string; className?: string }> }) {
   const codeString = children?.props?.children || ''
+  const className = children?.props?.className || ''
+  const language = className.replace(/language-/, '')
   return (
     <div className="relative group">
+      {language && (
+        <span className="absolute right-10 top-0 z-10 rounded-b-md bg-neutral-200 dark:bg-neutral-700 px-2 py-0.5 text-[11px] font-medium text-neutral-500 dark:text-neutral-400 select-none">
+          {language}
+        </span>
+      )}
       <CopyButton text={codeString} />
       <pre {...props}>
         {children}


### PR DESCRIPTION
## Summary
- Fix code block syntax highlighting by changing `--sh-*` CSS variables from `initial` to `inherit` in `.prose pre code`
- Add language label badge (e.g. `js`, `html`) to top-right of code blocks
- Fix bold markdown syntax in skeleton-screen-optimization article

## Test plan
- [ ] Verify code blocks have proper syntax highlighting (colors for keywords, strings, etc.)
- [ ] Verify language label appears on code blocks with language specifier
- [ ] Verify **新增改动1/2** renders as bold in the skeleton article

🤖 Generated with [Claude Code](https://claude.com/claude-code)