### PR TITLE
fix: table header style broken when system dark but page light

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('theme');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')}catch(e){}})()`,
+            __html: `(function(){try{var t=localStorage.getItem('theme');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark');else document.documentElement.classList.add('light')}catch(e){}})()`,
           }}
         />
       </head>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -25,6 +25,7 @@ export function ThemeToggle() {
       setIsDark(!isDark)
       localStorage.setItem('theme', next)
       document.documentElement.classList.toggle('dark', next === 'dark')
+      document.documentElement.classList.toggle('light', next === 'light')
     }
     if (!document.startViewTransition) {
       switchTheme()


### PR DESCRIPTION
## Summary
- When the OS prefers dark mode and the user toggles to light mode, the `.light` class was never added to `<html>`, so `@media (prefers-color-scheme: dark) { :root:not(.light) ... }` still matched — applying dark table header backgrounds (`#262626`) in light mode.
- Added `.light` class toggling in both the theme toggle component and the inline anti-flash script.

## Test plan
- [ ] Set system theme to dark, open the blog, toggle to light mode → verify table headers use light background (`#f5f5f5`)
- [ ] Toggle back to dark → verify table headers use dark background (`#262626`)
- [ ] Refresh page in light mode → verify `.light` class is present and table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)