### PR TITLE
chore(deps): override postcss to ^8.5.10 (CVE-2026-41305)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "react-simple-code-editor": "^0.14.1",
     "remark-gfm": "^4.0.1"
   },
+  "pnpm": {
+    "overrides": {
+      "postcss": "^8.5.10"
+    }
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: ^8.5.10
+
 importers:
 
   .:
@@ -70,7 +73,7 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.5)
       postcss:
-        specifier: ^8.5.12
+        specifier: ^8.5.10
         version: 8.5.12
       sugar-high:
         specifier: ^1.1.0
@@ -2050,10 +2053,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -4814,7 +4813,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.23
       caniuse-lite: 1.0.30001762
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.5)
@@ -4929,12 +4928,6 @@ snapshots:
   pirates@4.0.7: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.12:
     dependencies:


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#86](https://github.com/popring/popring.github.io/security/dependabot/86) — postcss < 8.5.10 (XSS via unescaped \`</style>\` in stringify, CVSS 6.1).
- Adds \`pnpm.overrides\` pinning postcss to \`^8.5.10\`. The vulnerable copy (8.4.31) only sneaks in transitively via \`next@16.2.4\`; Tailwind already resolves to 8.5.12.
- Lockfile now uses 8.5.12 across the tree, no other deps shifted.

## Test plan
- [x] \`pnpm install\` regenerates the lock cleanly
- [x] \`pnpm lint\` passes
- [x] \`pnpm build\` static export succeeds, all routes render
- [x] \`pnpm why postcss\` shows 8.5.12 from every entry point (no 8.4.31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)